### PR TITLE
Add support for jpeg extension

### DIFF
--- a/src/environment/config.js
+++ b/src/environment/config.js
@@ -18,6 +18,7 @@ const constants = {
         "png",
         "gif",
         "jpg",
+        "jpeg",
         "bmp",
         "webp",
         "jp2",


### PR DESCRIPTION
This PR adds support for the `jpeg` extension as a supported image type. 